### PR TITLE
Call to a member function connect() on null Laravel 8

### DIFF
--- a/src/RedisServiceProvider.php
+++ b/src/RedisServiceProvider.php
@@ -8,14 +8,21 @@ use Vemcogroup\Redis\Connectors\VemRedisConnector;
 
 class RedisServiceProvider extends ServiceProvider
 {
-    public function boot(): void
+    public function register(): void
     {
         throw_if(!extension_loaded('redis'),
             'The redis extension is not installed. Please install the extension to enable ' . __CLASS__
         );
 
-        Redis::extend('vredis', function () {
-            return new VemRedisConnector;
+        $this->app->booting(function () {
+            Redis::extend('vredis', function () {
+                return new VemRedisConnector;
+            });
         });
+    }
+    
+    public function boot(): void
+    {
+        //
     }
 }


### PR DESCRIPTION
When i tried to install this module on laravel 8 and configure .env with drive "vredis", i reiceved always this error: 
local.ERROR: Call to a member function connect() on null {"exception":"[object] (Error(code: 0): Call to a member function connect() on null at /var/www/vendor/laravel/framework/src/Illuminate/Redis/RedisManager.php:110)
From official Laravel documentation "https://laravel.com/docs/8.x/cache#registering-the-driver" have to change this provider.